### PR TITLE
PT代名詞の整列順を修正

### DIFF
--- a/ACT.SpecialSpellTimer/LogBuffer.cs
+++ b/ACT.SpecialSpellTimer/LogBuffer.cs
@@ -332,7 +332,7 @@
                     orderby
                     y.Role,
                     x.Job,
-                    x.ID
+                    x.ID descending
                     select
                     x.Name.Trim();
 


### PR DESCRIPTION
PT内に同Jobが複数いた場合、PT代名詞の整列順がプレイヤID昇順となっていたが、ゲーム側は降順となっているため、ソートルールを変更
